### PR TITLE
Fix warning when loading HTML files with invalid UTF-8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,7 @@ dependencies = [
  "egui_wgpu_backend",
  "egui_winit_platform",
  "embed-resource",
+ "encoding_rs",
  "env_logger",
  "epaint",
  "font-loader",
@@ -722,6 +723,15 @@ dependencies = [
  "cc",
  "vswhom",
  "winreg",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ copypasta = "0.7"
 directories = "3.0"
 egui = { version = "0.13", default-features = false, features = ["single_threaded"] }
 egui_wgpu_backend = "0.10"
+encoding_rs = "0.8"
 epaint = { version = "0.13", default-features = false, features = ["single_threaded"] }
 font-loader = "0.11"
 kuchiki = "0.8"

--- a/fixtures/VRS_21S2_ESS_P217_LeMans_R-safe.htm
+++ b/fixtures/VRS_21S2_ESS_P217_LeMans_R-safe.htm
@@ -1,0 +1,110 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html> 
+		<head> 
+			<title>iRacing.com Motorsport Simulations Car Setup</title> 
+			<meta name="GENERATOR" content="iRacing.com Simulator"> 
+		</head> 
+		 
+		<body> 
+		 
+			<H2 align="center">iRacing.com Motorsport Simulations<br> 
+			dallarap217 setup: LeMans\21S2\VRS_21S2_ESS_P217_LeMans_R-safe<br> 
+			track: lemans full</H2><br> 
+			<br> 
+	<br>
+<H2><U>LEFT FRONT TIRE:</U></H2>
+Starting pressure: <U>20.0 psi</U><br>Last hot pressure: <U>20.0 psi</U><br>Last temps O M I: <U>154F</U><br><U>154F</U><br><U>154F</U><br>Tread remaining: <U>100%</U><br><U>100%</U><br><U>100%</U><br><br>
+<H2><U>LEFT REAR TIRE:</U></H2>
+Starting pressure: <U>20.0 psi</U><br>Last hot pressure: <U>20.0 psi</U><br>Last temps O M I: <U>154F</U><br><U>154F</U><br><U>154F</U><br>Tread remaining: <U>100%</U><br><U>100%</U><br><U>100%</U><br><br>
+<H2><U>RIGHT FRONT TIRE:</U></H2>
+Starting pressure: <U>20.0 psi</U><br>Last hot pressure: <U>20.0 psi</U><br>Last temps I M O: <U>154F</U><br><U>154F</U><br><U>154F</U><br>Tread remaining: <U>100%</U><br><U>100%</U><br><U>100%</U><br><br>
+<H2><U>RIGHT REAR TIRE:</U></H2>
+Starting pressure: <U>20.0 psi</U><br>Last hot pressure: <U>20.0 psi</U><br>Last temps I M O: <U>154F</U><br><U>154F</U><br><U>154F</U><br>Tread remaining: <U>100%</U><br><U>100%</U><br><U>100%</U><br><br>
+<H2><U>AERO SETTINGS:</U></H2>
+Downforce trim: <U>Low</U><br>Rear wing angle: <U>12 deg</U><br># of dive planes: <U>1</U><br>Wing gurney setting: <U>Off</U><br>Deck gurney setting: <U>Off</U><br><br>
+<H2><U>AERO CALCULATOR:</U></H2>
+Front RH at speed: <U>1.575"</U><br>Rear RH at speed: <U>0.591"</U><br>Downforce balance: <U>40.83%</U><br>L/D: <U>5.057</U><br><br>
+<H2><U>FRONT:</U></H2>
+Third spring: <U>1086 lbs/in</U><br>Third perch offset: <U>0.728"</U><br>Third spring defl: <U>0.311 in</U><br>of <U>2.583 in</U><br>Third slider defl: <U>0.945 in</U><br>of <U>3.937 in</U><br>ARB size: <U> Soft</U><br>ARB blades: <U> P5 </U><br>Toe-in: <U>-2/32"</U><br>Third pin length: <U>7.480"</U><br>Front pushrod length: <U>7.303"</U><br>Power steering assist: <U>3</U><br>Steering ratio: <U>11.0</U><br>Display page: <U>Race1</U><br><br>
+<H2><U>LEFT FRONT:</U></H2>
+Corner weight: <U>527 lbs</U><br>Ride height: <U>1.775 in</U><br>Shock defl: <U>0.533 in</U><br>of <U>1.969 in</U><br>Torsion bar defl: <U>0.283 in</U><br>Torsion bar turns: <U>2.750 Turns</U><br>Torsion bar O.D.: <U> 13.90 mm </U><br>LS comp damping: <U>2 clicks</U><br>HS comp damping: <U>5 clicks</U><br>HS comp damp slope: <U>9 clicks</U><br>LS rbd damping: <U>4 clicks</U><br>HS rbd damping: <U>6 clicks</U><br>Camber: <U>-2.8 deg</U><br><br>
+<H2><U>LEFT REAR:</U></H2>
+Corner weight: <U>652 lbs</U><br>Ride height: <U>1.775 in</U><br>Shock defl: <U>1.346 in</U><br>of <U>2.953 in</U><br>Spring defl: <U>0.551 in</U><br>of <U>3.525 in</U><br>Spring perch offset: <U>1.890"</U><br>Spring rate: <U>600 lbs/in</U><br>LS comp damping: <U>2 clicks</U><br>HS comp damping: <U>5 clicks</U><br>HS comp damp slope: <U>9 clicks</U><br>LS rbd damping: <U>4 clicks</U><br>HS rbd damping: <U>6 clicks</U><br>Camber: <U>-1.8 deg</U><br>Toe-in: <U>+0/32"</U><br><br>
+<H2><U>RIGHT FRONT:</U></H2>
+Corner weight: <U>527 lbs</U><br>Ride height: <U>1.775 in</U><br>Shock defl: <U>0.533 in</U><br>of <U>1.969 in</U><br>Torsion bar defl: <U>0.283 in</U><br>Torsion bar turns: <U>2.750 Turns</U><br>Torsion bar O.D.: <U> 13.90 mm </U><br>LS comp damping: <U>2 clicks</U><br>HS comp damping: <U>5 clicks</U><br>HS comp damp slope: <U>9 clicks</U><br>LS rbd damping: <U>4 clicks</U><br>HS rbd damping: <U>6 clicks</U><br>Camber: <U>-2.8 deg</U><br><br>
+<H2><U>RIGHT REAR:</U></H2>
+Corner weight: <U>652 lbs</U><br>Ride height: <U>1.775 in</U><br>Shock defl: <U>1.346 in</U><br>of <U>2.953 in</U><br>Spring defl: <U>0.551 in</U><br>of <U>3.525 in</U><br>Spring perch offset: <U>1.890"</U><br>Spring rate: <U>600 lbs/in</U><br>LS comp damping: <U>2 clicks</U><br>HS comp damping: <U>5 clicks</U><br>HS comp damp slope: <U>9 clicks</U><br>LS rbd damping: <U>4 clicks</U><br>HS rbd damping: <U>6 clicks</U><br>Camber: <U>-1.8 deg</U><br>Toe-in: <U>+0/32"</U><br><br>
+<H2><U>REAR:</U></H2>
+Third spring: <U>743 lbs/in</U><br>Third perch offset: <U>1.220"</U><br>Third spring defl: <U>0.330 in</U><br>of <U>3.334 in</U><br>Third slider defl: <U>2.425 in</U><br>of <U>5.906 in</U><br>ARB size: <U> Soft</U><br>ARB blades: <U> P1</U><br>Rear pushrod length: <U>6.496"</U><br>Third pin length: <U>6.909"</U><br>Cross weight: <U>50.0%</U><br><br>
+<H2><U>LIGHTING:</U></H2>
+Roof ID light color: <U>Red</U><br><br>
+<H2><U>BRAKE SPEC:</U></H2>
+Pad compound: <U>High</U><br>Brake pressure bias: <U>49.5%</U><br><br>
+<H2><U>FUEL:</U></H2>
+Fuel level: <U>19.8 gal</U><br><br>
+<H2><U>TRACTION CONTROL:</U></H2>
+Traction control gain: <U>8 (TC)</U><br>Traction control slip: <U>5 (TC)</U><br>Throttle shape: <U>1</U><br><br>
+<H2><U>GEAR RATIOS:</U></H2>
+Gear stack: <U>Tall</U><br>Speed in first: <U>86.7 mph</U><br>Speed in second: <U>112.1 mph</U><br>Speed in third: <U>131.6 mph</U><br>Speed in forth: <U>156.3 mph</U><br>Speed in fifth: <U>182.7 mph</U><br>Speed in sixth: <U>210.2 mph</U><br><br>
+<H2><U>REAR DIFF SPEC:</U></H2>
+Drive/coast ramp angles: <U>45/55</U><br>Clutch friction faces: <U>10</U><br>Preload: <U>81 ft-lbs</U><br><br>
+<H2><U>Notes:</U></H2>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+Virtual Racing School - Martin Krönke<br>
+</body></html>


### PR DESCRIPTION
iRacing exports HTML using the Latin1 character set which is incompatible with UTF-8.