### PR TITLE
Fix empty group names

### DIFF
--- a/fixtures/iracing_w12_baseline_glenboot.htm
+++ b/fixtures/iracing_w12_baseline_glenboot.htm
@@ -1,0 +1,82 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html> 
+		<head> 
+			<title>iRacing.com Motorsport Simulations Car Setup</title> 
+			<meta name="GENERATOR" content="iRacing.com Simulator"> 
+		</head> 
+		 
+		<body> 
+		 
+			<H2 align="center">iRacing.com Motorsport Simulations<br> 
+			mercedesw12 setup: &lt;baseline&gt;<br> 
+			track: watkinsglen 2021 fullcourse</H2><br> 
+			<br> 
+	<br>
+<H2><U>TIRE COMPOUND:</U></H2>
+Tire compound: <U>Medium</U><br><br>
+<H2><U>LEFT FRONT TIRE:</U></H2>
+Starting pressure: <U>22.0 psi</U><br>Last hot pressure: <U>22.0 psi</U><br>Last temps O M I: <U>172F</U><br><U>172F</U><br><U>172F</U><br>Tread remaining: <U>100%</U><br><U>100%</U><br><U>100%</U><br><br>
+<H2><U>LEFT REAR TIRE:</U></H2>
+Starting pressure: <U>20.0 psi</U><br>Last hot pressure: <U>20.0 psi</U><br>Last temps O M I: <U>171F</U><br><U>171F</U><br><U>171F</U><br>Tread remaining: <U>100%</U><br><U>100%</U><br><U>100%</U><br><br>
+<H2><U>RIGHT FRONT TIRE:</U></H2>
+Starting pressure: <U>22.0 psi</U><br>Last hot pressure: <U>22.0 psi</U><br>Last temps I M O: <U>172F</U><br><U>172F</U><br><U>172F</U><br>Tread remaining: <U>100%</U><br><U>100%</U><br><U>100%</U><br><br>
+<H2><U>RIGHT REAR TIRE:</U></H2>
+Starting pressure: <U>20.0 psi</U><br>Last hot pressure: <U>20.0 psi</U><br>Last temps I M O: <U>171F</U><br><U>171F</U><br><U>171F</U><br>Tread remaining: <U>100%</U><br><U>100%</U><br><U>100%</U><br><br>
+<H2><U>AERO PACKAGE:</U></H2>
+Downforce trim: <U>High</U><br>Front flap offset: <U>1.75 deg</U><br>Rear wing Gurney: <U>0.591 in</U><br><br>
+<H2><U>AERO CALCULATOR:</U></H2>
+<br>
+<H2><U>Note: This section is for calculation purposes only </U></H2>
+<br>
+<H2><U>Use flap/Gurney above and ride heights at speed below to calculate aero balance</U></H2>
+Front RH at speed: <U>0.512"</U><br>Rear RH at speed: <U>2.835"</U><br>Aero balance: <U>44.80%</U><br>Downforce to drag: <U>4.393:1</U><br><br>
+<H2><U>FRONT:</U></H2>
+Transparent halo: <U>No</U><br>Weight dist: <U>48.0%</U><br>Heave rate: <U>4000 lbs/in</U><br>Roll rate: <U>2284 lb/in</U><br>Ride height: <U>0.950 in</U><br><br>
+<H2><U>LEFT FRONT:</U></H2>
+Corner weight: <U>499 lbs</U><br>Camber: <U>-3.48 deg</U><br>Toe-in: <U>-0.24 deg</U><br><br>
+<H2><U>LEFT REAR:</U></H2>
+Corner weight: <U>540 lbs</U><br>Camber: <U>-1.95 deg</U><br>Toe-in: <U>+0.10 deg</U><br><br>
+<H2><U>RIGHT FRONT:</U></H2>
+Corner weight: <U>499 lbs</U><br>Camber: <U>-3.48 deg</U><br>Toe-in: <U>-0.24 deg</U><br><br>
+<H2><U>RIGHT REAR:</U></H2>
+Corner weight: <U>540 lbs</U><br>Camber: <U>-1.95 deg</U><br>Toe-in: <U>+0.10 deg</U><br><br>
+<H2><U>REAR:</U></H2>
+Fuel level: <U>242.5 lb</U><br>Heave rate: <U>286 lbs/in</U><br>Roll rate: <U>1199 lb/in</U><br>Ride height: <U>5.442 in</U><br><br>
+<H2><U>DIFFERENTIAL:</U></H2>
+Preload: <U>0 ft-lbs</U><br>Entry: <U>1 (ENTRY)</U><br>Middle: <U>2 (MID)</U><br>High speed: <U>3 (HISPD)</U><br><br>
+<H2><U>POWER UNIT CONFIG:</U></H2>
+MGU-K deploy mode: <U>Balanced</U><br>Engine braking: <U>10 (EB)</U><br><br>
+<H2><U>BRAKE SYSTEM CONFIG:</U></H2>
+Base brake bias: <U>57.0% (BBAL)</U><br>Dynamic ramping: <U>50% pedal</U><br>Brake migration: <U>1 (BMIG)</U><br>Total brake bias: <U>57.0% front</U><br>Brake magic modifier: <U>0.75</U><br><br>
+<H2><U>Notes:</U></H2>
+Aero adjustments:<br>
+
+<br>
+
+More front wing will increase downforce and move aero balance forward. Counter this if necessary with more rear gurney. Using the aero calculator and focusing on keeping the front downforce percentage the same should keep the balance the same after adjustments.<br>
+
+<br>
+
+Increasing the roll rates can increase downforce slightly in high speed corners by controlling the aero platform better.<br>
+
+<br>
+
+Mechanical adjustments:<br>
+
+<br>
+
+Softer roll rates may increase speeds through slow speed corners while making higher speed corners more unstable and/or slower.<br>
+
+<br>
+
+Hovering over an adjustment will give additional information on adjustments and their effects.<br>
+
+<br>
+
+Tire Compounds:<br>
+
+<br>
+
+The soft tire is the fastest tire, with the worst life. The hard tire is the slowest tire with the longest life. On cold tracks with high usage, expect the soft tire to be much more effective against harder compounds than on hotter tracks with low usage.<br>
+
+</body></html>

--- a/src/setup/tests.rs
+++ b/src/setup/tests.rs
@@ -57,7 +57,17 @@ fn test_load_dir() {
     assert_eq!(file_name, "baseline");
     assert_eq!(porche911.keys().len(), 12);
 
-    assert_eq!(setups.tracks().len(), 4);
+    let cars = &tracks["Watkins Glen International - Boot"]["Mercedes-AMG W12 E Performance"];
+    assert_eq!(cars.len(), 1);
+    let SetupInfo {
+        setup: mercedes,
+        name: file_name,
+        ..
+    } = &cars[0];
+    assert_eq!(file_name, "iracing_w12_baseline_glenboot");
+    assert_eq!(mercedes.keys().len(), 16);
+
+    assert_eq!(setups.tracks().len(), 5);
 }
 
 #[test]
@@ -710,6 +720,185 @@ fn test_setup_porche_911_gt3_r() {
 }
 
 #[test]
+fn test_setup_mercedes_amg_w12() {
+    let config = Config::new("/tmp/some/path.toml", PhysicalSize::new(0, 0));
+    let (track_name, car_name, setup) =
+        setup_from_html("./fixtures/iracing_w12_baseline_glenboot.htm", &config).unwrap();
+
+    assert_eq!(track_name, "Watkins Glen International - Boot".to_string());
+    assert_eq!(car_name, "Mercedes-AMG W12 E Performance".to_string());
+    assert_eq!(setup.keys().len(), 16);
+
+    dbg!(&setup);
+
+    // Tire Compound
+    let expected = create_ordered_multimap(&[("Tire compound", "Medium")]);
+    let left_front_tire = setup.get("Tire Compound").unwrap();
+    assert_eq!(left_front_tire, &expected);
+
+    // Left Front Tire
+    let expected = create_ordered_multimap(&[
+        ("Starting pressure", "22.0 psi"),
+        ("Last hot pressure", "22.0 psi"),
+        ("Last temps O M I", "172F"),
+        ("Last temps O M I", "172F"),
+        ("Last temps O M I", "172F"),
+        ("Tread remaining", "100%"),
+        ("Tread remaining", "100%"),
+        ("Tread remaining", "100%"),
+    ]);
+    let left_front_tire = setup.get("Left Front Tire").unwrap();
+    assert_eq!(left_front_tire, &expected);
+
+    // Left Rear Tire
+    let expected = create_ordered_multimap(&[
+        ("Starting pressure", "20.0 psi"),
+        ("Last hot pressure", "20.0 psi"),
+        ("Last temps O M I", "171F"),
+        ("Last temps O M I", "171F"),
+        ("Last temps O M I", "171F"),
+        ("Tread remaining", "100%"),
+        ("Tread remaining", "100%"),
+        ("Tread remaining", "100%"),
+    ]);
+    let left_rear_tire = setup.get("Left Rear Tire").unwrap();
+    assert_eq!(left_rear_tire, &expected);
+
+    // Right Front Tire
+    let expected = create_ordered_multimap(&[
+        ("Starting pressure", "22.0 psi"),
+        ("Last hot pressure", "22.0 psi"),
+        ("Last temps I M O", "172F"),
+        ("Last temps I M O", "172F"),
+        ("Last temps I M O", "172F"),
+        ("Tread remaining", "100%"),
+        ("Tread remaining", "100%"),
+        ("Tread remaining", "100%"),
+    ]);
+    let right_front_tire = setup.get("Right Front Tire").unwrap();
+    assert_eq!(right_front_tire, &expected);
+
+    // Right Rear Tire
+    let expected = create_ordered_multimap(&[
+        ("Starting pressure", "20.0 psi"),
+        ("Last hot pressure", "20.0 psi"),
+        ("Last temps I M O", "171F"),
+        ("Last temps I M O", "171F"),
+        ("Last temps I M O", "171F"),
+        ("Tread remaining", "100%"),
+        ("Tread remaining", "100%"),
+        ("Tread remaining", "100%"),
+    ]);
+    let right_rear_tire = setup.get("Right Rear Tire").unwrap();
+    assert_eq!(right_rear_tire, &expected);
+
+    // Aero Package
+    let expected = create_ordered_multimap(&[
+        ("Downforce trim", "High"),
+        ("Front flap offset", "1.75 deg"),
+        ("Rear wing Gurney", "0.591 in"),
+    ]);
+    let aero_package = setup.get("Aero Package").unwrap();
+    assert_eq!(aero_package, &expected);
+
+    // Aero Calculator
+    let expected = create_ordered_multimap(&[
+        ("Front RH at speed", r#"0.512""#),
+        ("Rear RH at speed", r#"2.835""#),
+        ("Aero balance", "44.80%"),
+        ("Downforce to drag", "4.393:1"),
+    ]);
+    let aero_calculator = setup.get("Aero Calculator").unwrap();
+    assert_eq!(aero_calculator, &expected);
+
+    // Front
+    let expected = create_ordered_multimap(&[
+        ("Transparent halo", "No"),
+        ("Weight dist", "48.0%"),
+        ("Heave rate", "4000 lbs/in"),
+        ("Roll rate", "2284 lb/in"),
+        ("Ride height", "0.950 in"),
+    ]);
+    let front = setup.get("Front").unwrap();
+    assert_eq!(front, &expected);
+
+    // Left Front
+    let expected = create_ordered_multimap(&[
+        ("Corner weight", "499 lbs"),
+        ("Camber", "-3.48 deg"),
+        ("Toe-in", "-0.24 deg"),
+    ]);
+    let left_front = setup.get("Left Front").unwrap();
+    assert_eq!(left_front, &expected);
+
+    // Left Rear
+    let expected = create_ordered_multimap(&[
+        ("Corner weight", "540 lbs"),
+        ("Camber", "-1.95 deg"),
+        ("Toe-in", "+0.10 deg"),
+    ]);
+    let left_rear = setup.get("Left Rear").unwrap();
+    assert_eq!(left_rear, &expected);
+
+    // Right Front
+    let expected = create_ordered_multimap(&[
+        ("Corner weight", "499 lbs"),
+        ("Camber", "-3.48 deg"),
+        ("Toe-in", "-0.24 deg"),
+    ]);
+    let right_front = setup.get("Right Front").unwrap();
+    assert_eq!(right_front, &expected);
+
+    // Right Rear
+    let expected = create_ordered_multimap(&[
+        ("Corner weight", "540 lbs"),
+        ("Camber", "-1.95 deg"),
+        ("Toe-in", "+0.10 deg"),
+    ]);
+    let right_rear = setup.get("Right Rear").unwrap();
+    assert_eq!(right_rear, &expected);
+
+    // Rear
+    let expected = create_ordered_multimap(&[
+        ("Fuel level", "242.5 lb"),
+        ("Heave rate", "286 lbs/in"),
+        ("Roll rate", "1199 lb/in"),
+        ("Ride height", "5.442 in"),
+    ]);
+    let rear = setup.get("Rear").unwrap();
+    assert_eq!(rear, &expected);
+
+    // Differential
+    let expected = create_ordered_multimap(&[
+        ("Preload", "0 ft-lbs"),
+        ("Entry", "1 (ENTRY)"),
+        ("Middle", "2 (MID)"),
+        ("High speed", "3 (HISPD)"),
+    ]);
+    let differential = setup.get("Differential").unwrap();
+    assert_eq!(differential, &expected);
+
+    // Power Unit Config
+    let expected = create_ordered_multimap(&[
+        ("MGU-K deploy mode", "Balanced"),
+        ("Engine braking", "10 (EB)"),
+    ]);
+    let power_unit_config = setup.get("Power Unit Config").unwrap();
+    assert_eq!(power_unit_config, &expected);
+
+    // Brake System Config
+    let expected = create_ordered_multimap(&[
+        ("Base brake bias", "57.0% (BBAL)"),
+        ("Dynamic ramping", "50% pedal"),
+        ("Brake migration", "1 (BMIG)"),
+        ("Total brake bias", "57.0% front"),
+        ("Brake magic modifier", "0.75"),
+    ]);
+    let brake_system_config = setup.get("Brake System Config").unwrap();
+    assert_eq!(brake_system_config, &expected);
+}
+
+#[test]
 fn test_add_setup() {
     use UpdateKind::*;
 
@@ -761,10 +950,11 @@ fn test_remove_setup() {
 
     fn assert_removed(setups: &Setups) {
         let tracks = setups.tracks();
-        assert_eq!(tracks.len(), 3);
+        assert_eq!(tracks.len(), 4);
         assert!(tracks.contains_key("Centripetal Circuit"));
         assert!(tracks.contains_key("Charlotte Motor Speedway - Legends Oval"));
         assert!(tracks.contains_key("Circuit des 24 Heures du Mans - 24 Heures du Mans"));
+        assert!(tracks.contains_key("Watkins Glen International - Boot"));
     }
 
     let mut config = Config::new("/tmp/some/path.toml", PhysicalSize::new(0, 0));
@@ -773,11 +963,12 @@ fn test_remove_setup() {
     let mut setups = Setups::new(&mut warnings, &config);
 
     let tracks = setups.tracks();
-    assert_eq!(tracks.len(), 4);
+    assert_eq!(tracks.len(), 5);
     assert!(tracks.contains_key("Centripetal Circuit"));
     assert!(tracks.contains_key("Charlotte Motor Speedway - Legends Oval"));
     assert!(tracks.contains_key("Circuit des 24 Heures du Mans - 24 Heures du Mans"));
     assert!(tracks.contains_key("Nürburgring Combined"));
+    assert!(tracks.contains_key("Watkins Glen International - Boot"));
 
     let mut result = Vec::new();
     let path = Path::new("./fixtures/baseline.htm")


### PR DESCRIPTION
Setup exports for the new Mercedes-AMG W12 contains notes where we expect to find group names. This PR ignores the notes to fix the immediate bug.

It would be nice to display the general setup notes. The notes mentioned in this specific issue should also be included in some way. That will be a separate PR.